### PR TITLE
GPU: Remove the assert that required the CODE_ADDRESS to be 0.

### DIFF
--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -75,14 +75,6 @@ void Maxwell3D::WriteReg(u32 method, u32 value, u32 remaining_params) {
         ProcessMacroUpload(value);
         break;
     }
-    case MAXWELL3D_REG_INDEX(code_address.code_address_high):
-    case MAXWELL3D_REG_INDEX(code_address.code_address_low): {
-        // Note: For some reason games (like Puyo Puyo Tetris) seem to write 0 to the CODE_ADDRESS
-        // register, we do not currently know if that's intended or a bug, so we assert it lest
-        // stuff breaks in other places (like the shader address calculation).
-        ASSERT_MSG(regs.code_address.CodeAddress() == 0, "Unexpected CODE_ADDRESS register value.");
-        break;
-    }
     case MAXWELL3D_REG_INDEX(const_buffer.cb_data[0]):
     case MAXWELL3D_REG_INDEX(const_buffer.cb_data[1]):
     case MAXWELL3D_REG_INDEX(const_buffer.cb_data[2]):


### PR DESCRIPTION
Games usually just leave it at 0 but nouveau sets it to something else. This already works fine, the assert is useless.